### PR TITLE
Add pagination in the "Countries" page

### DIFF
--- a/patches/@types+react-native+0.67.4.patch
+++ b/patches/@types+react-native+0.67.4.patch
@@ -1,7 +1,94 @@
 diff --git a/node_modules/@types/react-native/globals.d.ts b/node_modules/@types/react-native/globals.d.ts
-index 8b41056..5f96e22 100755
+index 8b41056..4028e39 100755
 --- a/node_modules/@types/react-native/globals.d.ts
 +++ b/node_modules/@types/react-native/globals.d.ts
+@@ -296,48 +296,48 @@ declare type XMLHttpRequestResponseType = '' | 'arraybuffer' | 'blob' | 'documen
+  * The properties are mutable to support users that use a `URL` polyfill, but the implementation
+  * built into React Native (as of 0.63) does not implement all the properties.
+  */
+-declare class URL {
+-    static createObjectURL(blob: Blob): string;
+-    static revokeObjectURL(url: string): void;
+-
+-    constructor(url: string, base?: string);
+-
+-    href: string;
+-    readonly origin: string;
+-    protocol: string;
+-    username: string;
+-    password: string;
+-    host: string;
+-    hostname: string;
+-    port: string;
+-    pathname: string;
+-    search: string;
+-    readonly searchParams: URLSearchParams;
+-    hash: string;
+-
+-    toJSON(): string;
+-}
++// declare class URL {
++//     static createObjectURL(blob: Blob): string;
++//     static revokeObjectURL(url: string): void;
++
++//     constructor(url: string, base?: string);
++
++//     href: string;
++//     readonly origin: string;
++//     protocol: string;
++//     username: string;
++//     password: string;
++//     host: string;
++//     hostname: string;
++//     port: string;
++//     pathname: string;
++//     search: string;
++//     readonly searchParams: URLSearchParams;
++//     hash: string;
++
++//     toJSON(): string;
++// }
+ 
+ /**
+  * Based on definitions of lib.dom and lib.dom.iterable
+  */
+-declare class URLSearchParams {
+-    constructor(init?: string[][] | Record<string, string> | string | URLSearchParams);
+-
+-    append(name: string, value: string): void;
+-    delete(name: string): void;
+-    get(name: string): string | null;
+-    getAll(name: string): string[];
+-    has(name: string): boolean;
+-    set(name: string, value: string): void;
+-    sort(): void;
+-    forEach(callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any): void;
+-    [Symbol.iterator](): IterableIterator<[string, string]>;
+-
+-    entries(): IterableIterator<[string, string]>;
+-    keys(): IterableIterator<string>;
+-    values(): IterableIterator<string>;
+-}
++// declare class URLSearchParams {
++//     constructor(init?: string[][] | Record<string, string> | string | URLSearchParams);
++
++//     append(name: string, value: string): void;
++//     delete(name: string): void;
++//     get(name: string): string | null;
++//     getAll(name: string): string[];
++//     has(name: string): boolean;
++//     set(name: string, value: string): void;
++//     sort(): void;
++//     forEach(callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any): void;
++//     [Symbol.iterator](): IterableIterator<[string, string]>;
++
++//     entries(): IterableIterator<[string, string]>;
++//     keys(): IterableIterator<string>;
++//     values(): IterableIterator<string>;
++// }
+ 
+ interface WebSocketMessageEvent extends Event {
+     data?: any;
 @@ -397,55 +397,55 @@ interface AbortEvent extends Event {
      type: 'abort';
  }

--- a/src/components/CountryList/index.tsx
+++ b/src/components/CountryList/index.tsx
@@ -9,9 +9,24 @@ import styles, { Constants as StyleConstants } from './styles';
 
 interface CountryListProps {
   countries: CountryTileProps[];
+  onEndReached: () => void;
+  ListFooterComponent:
+    | React.ReactElement<
+        CountryTileProps,
+        string | React.JSXElementConstructor<CountryTileProps>
+      >
+    | React.ComponentType<CountryTileProps>
+    | null
+    | undefined;
+  onMomentumScrollBegin: () => void;
 }
 
-const CountryList = ({ countries }: CountryListProps): JSX.Element => {
+const CountryList = ({
+  countries,
+  onEndReached,
+  ListFooterComponent,
+  onMomentumScrollBegin,
+}: CountryListProps): JSX.Element => {
   const tabBarHeight = useBottomTabBarHeight();
 
   const renderItem = React.useCallback(
@@ -40,6 +55,10 @@ const CountryList = ({ countries }: CountryListProps): JSX.Element => {
           },
         ]}
         ItemSeparatorComponent={ItemSeparator}
+        onEndReachedThreshold={0.01}
+        onEndReached={onEndReached}
+        ListFooterComponent={ListFooterComponent}
+        onMomentumScrollBegin={onMomentumScrollBegin}
       />
     </SafeAreaView>
   );

--- a/src/components/LoadingOrTapToRefresh/index.tsx
+++ b/src/components/LoadingOrTapToRefresh/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { ApolloError, ApolloQueryResult } from '@apollo/client';
+
+import Loader from 'components/Loader';
+import Error from 'components/Error';
+
+interface Props<T> {
+  data: T;
+  error: ApolloError | undefined;
+  loading: boolean;
+  refetch: () => Promise<ApolloQueryResult<T>>;
+}
+
+const LoadingOrTapToRefresh = <T,>({
+  data,
+  error,
+  loading,
+  refetch,
+}: Props<T>): JSX.Element | null => {
+  if (loading) return <Loader />;
+  if (!data || error) return <Error refetch={refetch} />;
+  return null;
+};
+
+export default LoadingOrTapToRefresh;

--- a/src/state/create-client.ts
+++ b/src/state/create-client.ts
@@ -24,7 +24,28 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
   if (networkError) console.log(`[Network error]: ${networkError}`);
 });
 
-const cache = new InMemoryCache();
+const cache = new InMemoryCache({
+  typePolicies: {
+    Query: {
+      fields: {
+        countries: {
+          keyArgs: [],
+          merge(existing, incoming) {
+            if (existing && existing.edges && incoming.edges) {
+              const merged = {
+                ...existing,
+                ...incoming,
+                edges: [...existing.edges, ...incoming.edges],
+              };
+              return merged;
+            }
+            return incoming;
+          },
+        },
+      },
+    },
+  },
+});
 
 const init = async (
   client: ApolloClient<NormalizedCacheObject>,

--- a/src/state/remote/__generated__/default.ts
+++ b/src/state/remote/__generated__/default.ts
@@ -366,7 +366,7 @@ export type GetCountriesQueryVariables = Exact<{
 }>;
 
 
-export type GetCountriesQuery = { __typename?: 'Query', countries: { __typename?: 'CountryConnection', edges: Array<{ __typename?: 'CountryEdge', node: { __typename?: 'Country', id: number, name: string, capital: string, emoji: string } }> } };
+export type GetCountriesQuery = { __typename?: 'Query', countries: { __typename?: 'CountryConnection', edges: Array<{ __typename?: 'CountryEdge', node: { __typename?: 'Country', id: number, name: string, capital: string, emoji: string } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } } };
 
 export type GetCountryQueryVariables = Exact<{
   id?: InputMaybe<Scalars['Int']>;
@@ -386,6 +386,10 @@ export const GetCountriesDocument = gql`
         capital
         emoji
       }
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
     }
   }
 }
@@ -475,6 +479,7 @@ export namespace GetCountries {
   export type Countries = (NonNullable<GetCountriesQuery['countries']>);
   export type Edges = NonNullable<(NonNullable<(NonNullable<GetCountriesQuery['countries']>)['edges']>)[number]>;
   export type Node = (NonNullable<NonNullable<(NonNullable<(NonNullable<GetCountriesQuery['countries']>)['edges']>)[number]>['node']>);
+  export type PageInfo = (NonNullable<(NonNullable<GetCountriesQuery['countries']>)['pageInfo']>);
   export const Document = GetCountriesDocument;
   export const use = useGetCountriesQuery;
 }

--- a/src/state/remote/use-get-countries.ts
+++ b/src/state/remote/use-get-countries.ts
@@ -19,6 +19,10 @@ export const query = gql`
           emoji
         }
       }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
     }
   }
 `;


### PR DESCRIPTION
## Description

Update the "Countries" page so now we can use the `fetchMore` functionality to fetch more data as the user scrolls down in the `FlatList`.
A few changes were necessary and they were explained throughout the commits.

## Visual references

https://user-images.githubusercontent.com/16086636/163896197-b59380fe-2d24-46a0-964f-2e697a63d020.mov

